### PR TITLE
refactor(namespace): standardize naming to "FilamentWebpush"

### DIFF
--- a/docs/custom-configuration.md
+++ b/docs/custom-configuration.md
@@ -40,8 +40,8 @@ You can listen for subscription events in your application:
 ```php
 use NotificationChannels\WebPush\Events\NotificationSent;
 use NotificationChannels\WebPush\Events\NotificationFailed;
-use FilamentWebPush\Events\PushSubscriptionCreated;
-use FilamentWebPush\Events\PushSubscriptionDeleted;
+use FilamentWebpush\Events\PushSubscriptionCreated;
+use FilamentWebpush\Events\PushSubscriptionDeleted;
 
 protected $listen = [
     NotificationSent::class => [

--- a/src/Events/PushSubscriptionCreated.php
+++ b/src/Events/PushSubscriptionCreated.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace FilamentWebPush\Events;
+namespace FilamentWebpush\Events;
 
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Auth\User;

--- a/src/Events/PushSubscriptionDeleted.php
+++ b/src/Events/PushSubscriptionDeleted.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace FilamentWebPush\Events;
+namespace FilamentWebpush\Events;
 
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Auth\User;

--- a/src/FilamentWebpushPlugin.php
+++ b/src/FilamentWebpushPlugin.php
@@ -10,7 +10,7 @@ use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\Support\Facades\FilamentView;
 use Filament\View\PanelsRenderHook;
 use FilamentWebpush\Filament\Widgets\WebpushSubscriptionStats;
-use FilamentWebPush\Http\Controllers\PushSubscriptionController;
+use FilamentWebpush\Http\Controllers\PushSubscriptionController;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 

--- a/src/Http/Controllers/PushSubscriptionController.php
+++ b/src/Http/Controllers/PushSubscriptionController.php
@@ -2,10 +2,10 @@
 
 declare(strict_types = 1);
 
-namespace FilamentWebPush\Http\Controllers;
+namespace FilamentWebpush\Http\Controllers;
 
-use FilamentWebPush\Events\PushSubscriptionCreated;
-use FilamentWebPush\Events\PushSubscriptionDeleted;
+use FilamentWebpush\Events\PushSubscriptionCreated;
+use FilamentWebpush\Events\PushSubscriptionDeleted;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;


### PR DESCRIPTION
update namespaces across events, controllers, and plugin for consistency matching the `FilamentWebpush` casing standard in source files and documentation