### PR TITLE
fix: use collection count

### DIFF
--- a/src/Filament/Widgets/WebpushSubscriptionStats.php
+++ b/src/Filament/Widgets/WebpushSubscriptionStats.php
@@ -19,8 +19,10 @@ class WebpushSubscriptionStats extends BaseWidget
         $table = config('webpush.table_name', 'push_subscriptions');
 
         $activeSubscriptions = DB::table($table)
-            ->distinct(['subscribable_id', 'subscribable_type'])
-            ->count(['subscribable_id', 'subscribable_type']);
+            ->select('subscribable_id', 'subscribable_type')
+            ->groupBy('subscribable_id', 'subscribable_type')
+            ->get()
+            ->count();
 
         $totalSubscriptions = DB::table($table)->count();
 


### PR DESCRIPTION
This pull request modifies the `getStats` method in the `WebpushSubscriptionStats` widget to improve the accuracy of counting active subscriptions by changing the query logic.

**Changes to query logic for subscription stats:**

* Updated the query in `protected function getStats()` in `src/Filament/Widgets/WebpushSubscriptionStats.php` to use `select` and `groupBy` for counting distinct `subscribable_id` and `subscribable_type`, replacing the previous `distinct` and `count` combination. This ensures the count is based on grouped results rather than distinct rows.